### PR TITLE
Shriv review

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,20 +2,20 @@ Package: motroadsafety
 Type: Package
 Title: Analyse Data for Road Safety Resaearch
 Version: 0.1.0
-Authors@R: Kathlyn Ycong, Simon Urbanek, Shrividya Ravi
+Authors: Kathlyn Ycong, Simon Urbanek, Shrividya Ravi
 Maintainer: Kathlyn Ycong <kyco720@aucklanduni.ac.nz>
-Description: Tools to help process and analyse road safety data from Stats NZ 
-and crash data from Waka Kotahi (NZ Transport Agency).
+Description: Tools to help process and analyse road safety data from Stats NZ and crash data from Waka Kotahi (NZ Transport Agency).
 License: What license is it under?
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.1.2
 Depends: 
-    R (>= 2.10)
+    R (>= 2.10),
+    rJava
 Imports:
-    ghroute,
     sf,
     dplyr,
-    purrr
-    
-
+    purrr,
+    ghroute
+Remotes:
+    github::s-u/ghroute

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,6 +16,7 @@ Imports:
     sf,
     dplyr,
     purrr,
-    ghroute
+    ghroute,
+    magrittr
 Remotes:
     github::s-u/ghroute

--- a/R/get_routes.R
+++ b/R/get_routes.R
@@ -14,7 +14,9 @@ get_routes <- function(lat_source, lng_source, lat_dest, lng_dest, osm_dir){
   #checking NZ osm file is available
   if(missing(osm_dir)){
     if (!file.exists("new-zealand-latest.osm.pbf")){
-      download.file("https://download.geofabrik.de/australia-oceania/new-zealand-latest.osm.pbf", "new-zealand-latest.osm.pbf")
+      download.file(url = "https://download.geofabrik.de/australia-oceania/new-zealand-latest.osm.pbf",
+                    destfile = "new-zealand-latest.osm.pbf",
+                    mode = "wb")
       warning("Downloading osm pbf file from https://download.geofabrik.de/australia-oceania/new-zealand-latest.osm.pbf")
     }
     osm_dir <- "new-zealand-latest.osm.pbf"   }

--- a/R/utils-pipe.R
+++ b/R/utils-pipe.R
@@ -1,0 +1,14 @@
+#' Pipe operator
+#'
+#' See \code{magrittr::\link[magrittr:pipe]{\%>\%}} for details.
+#'
+#' @name %>%
+#' @rdname pipe
+#' @keywords internal
+#' @export
+#' @importFrom magrittr %>%
+#' @usage lhs \%>\% rhs
+#' @param lhs A value or the magrittr placeholder.
+#' @param rhs A function call using the magrittr semantics.
+#' @return The result of calling `rhs(lhs)`.
+NULL


### PR DESCRIPTION
Package looks good! I only did some cursory testing and noting down the issues for posterity. Fixes to some are in this PR. 

## Notes on issues
- Installation issues. Some problems in text and `ghroute` couldn't be installed properly. Fix in PR. 
-  `ghroute` didn't install properly `ERROR: dependency 'ghroute' is not available for package 'motroadsafety'`. Error because package is not on CRAN. Needed to add Remotes pointer to Github repo in DESCRIPTION so that package is installed from github source. I did the following to install locally. Noting to install `rJava` before installing `ghroute`. In package this was managed by adding rJava as a dependency rather than an import. 

```
install.packages("rJava")
install.packages("ghroute",,"http://rforge.net/",type="source")
```

- Some problem with automatically download of pbf file from https://download.geofabrik.de/australia-oceania/new-zealand-latest.osm.pbf. Need to write the file in binary mode with the `mode = 'wb'` option in `download.file()` [as per man page](https://www.rdocumentation.org/packages/utils/versions/3.6.2/topics/download.file). Fix in PR. 
```
12:16:08.250 [main] INFO com.graphhopper.reader.osm.OSMReader - Starting to process OSM file: 'new-zealand-latest.osm.pbf'
Error in .jcall("RJavaTools", "Ljava/lang/Object;", "invokeMethod", cl,  : 
  java.lang.RuntimeException: Problem while parsing file
```

- I kept getting Java memory error when building the `graphhopper-cache`.  Need to restart Rstudio and run `options(java.parameters = c("-XX:+UseConcMarkSweepGC", "-Xmx8192m"))` followed by `gc()`. Solution from one of the responses in [this S/O post](https://stackoverflow.com/questions/34624002/r-error-java-lang-outofmemoryerror-java-heap-space). Once the cache is built, the java memory is not required. 

- Can't seem to run on a subset of the full data.. which is super weird! Get this error `Error in valid_numeric_matrix(x) : is.matrix(x) is not TRUE`
